### PR TITLE
Add eslint-disable & css

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -13,6 +13,7 @@
 </template>
 
 <script>
+/* eslint-disable */
 import Navbar from '@/components/Navbar'
 const device = mobileAndTabletCheck() ? 'mobile' : 'desktop'
 let userPageView = parseInt(sessionStorage.getItem('userPageView'))

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -111,14 +111,21 @@ export default {
 }
 
 .badge {
-  display: none;
+  font-size: 110%;
   margin-right: 10px;
+  display: inline-block;
+  display: none;
 }
 
 .cart-text {
-  font-size: 1.2em;
   cursor: pointer;
 }
+
+.fa-shopping-cart {
+  font-size: 25px;
+  display: inline-block;
+}
+
 .navbar-collapse {
   flex-grow: 0;
 }


### PR DESCRIPTION
1.添加 eslint-disable 標示在 App.vue 中，跑 npm run lint 時，會忽略正規表達式 (Regular Expression) 的錯誤，可以先檢查駝峰 (camel-case) 命名的問題

2.前端非駝峰關鍵字有：payment_status、shipping_status，npm run lint 沒有呈現 Html 裡面的非駝峰命名，只有把 JS 的部分找出，需要用 vscode 內建搜尋功能查找